### PR TITLE
Use limactl json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 [Lima](https://github.com/lima-vm/lima) is an alternative to using Docker Desktop on your Mac.
 
-This plugin is compatible with [xbar](https://xbarapp.com/) and [SwiftBar](https://github.com/swiftbar/SwiftBar), and lets you start and stop lima VMs from the menubar.
+## Description
 
 ![Screen shot of Lima menu with a running vm](https://raw.githubusercontent.com/unixorn/lima-xbar-plugin/main/pix/limactl-screen-shot.png)
+
+This plugin is compatible with [xbar](https://xbarapp.com/) and [SwiftBar](https://github.com/swiftbar/SwiftBar), and lets you start and stop lima VMs from the menubar.
+
+## Installation
+
+### Dependencies
+
+- [xbar](https://xbarapp.com/) - Allows you to make custom menubar apps with just scripts
+
+- [jq](https://stedolan.github.io/jq/) - `brew install jq` - Used to parse the output of `limactl`

--- a/lima-plugin
+++ b/lima-plugin
@@ -91,10 +91,13 @@ function printMenuBarIcon() {
   local limaStatus
   local menuBarIcon
   menuBarIcon="🐋 ⛔ | color=$STOPPED_VM_COLOR"
-  limaStatus="$(limactl list --json | jq -r '.status')"
-  if [[ "$limaStatus" == 'Running' ]]; then
-    menuBarIcon="🐋 🏃 | color=$RUNNING_VM_COLOR"
-  fi
+
+  for vm in $(limactl list --json | jq -r '.status')
+  do
+    if [[ "$vm" == 'Running' ]]; then
+      menuBarIcon="🐋 🏃 | color=$RUNNING_VM_COLOR"
+    fi
+  done
   echo "$menuBarIcon"
   echo '---'
 }
@@ -104,15 +107,19 @@ function printMenu() {
 
   printMenuBarIcon
 
-  for limavm in $(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | awk '{ print $1 }')
+  local name
+  local vmstatus
+
+  for raw in $(limactl list --json)
   do
-    vmstatus=$(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | grep "$limavm" | awk '{ print $2 }')
-    if [[ "$vmstatus" == 'Running' ]]; then
-      menuItem="$limavm VM is running - ⛔ | color=$RUNNING_VM_COLOR | bash=$XBAR_PLUGIN param1=stop param2=$limavm terminal=false refresh=true"
+    name=$(echo $raw | jq -r '.name' )
+    vmstatus=$(echo $raw | jq -r '.status')
+    if [[ $vmstatus == 'Running' ]]; then
+      menuItem="$name VM is running - ⛔ | color=$RUNNING_VM_COLOR | bash=$XBAR_PLUGIN param1=stop param2=$name terminal=false refresh=true"
     else
-      menuItem="$limavm VM is stopped - ▶️ | color=$STOPPED_VM_COLOR | bash=$XBAR_PLUGIN param1=start param2=$limavm terminal=false refresh=true"
+      menuItem="$name VM is stopped - ▶️ | color=$STOPPED_VM_COLOR | bash=$XBAR_PLUGIN param1=start param2=$name terminal=false refresh=true"
     fi
-    echo "$menuItem"
+    echo $menuItem
   done
 
   echo "force rescan | bash=limactl param1=list terminal=false refresh=true"

--- a/lima-plugin
+++ b/lima-plugin
@@ -14,11 +14,12 @@
 #
 # Dependencies: 
 #   lima - https://github.com/lima-vm/lima
+#   jq - https://stedolan.github.io/jq/
 
-# InService output color (default green)
+# Running VM color (default green)
 RUNNING_VM_COLOR="#29cc00"
 
-# OutOfService output color (default red)
+# Stopped VM color (default red)
 STOPPED_VM_COLOR="#ff0033"
 
 set -o pipefail
@@ -65,7 +66,28 @@ logger -t 'limamenu' "RUNNING_VM_COLOR=$RUNNING_VM_COLOR"
 logger -t 'limamenu' "STOPPED_VM_COLOR=$STOPPED_VM_COLOR"
 logger -t 'limamenu' "XBAR_PLUGIN=$XBAR_PLUGIN"
 
+# shellcheck disable=SC2059
+function warnIfMissingDependencies() {
+  local depsOK=1
+  local warnings=""
+  if ! has limactl; then
+    warnings=$(printf "${warnings}limactl is not in your PATH! - click to get started | color=$STOPPED_VM_COLOR href=https://github.com/lima-vm/lima#getting-started\n")
+    depsOK=0
+  fi
+  if ! has jq; then
+    warnings=$(printf "${warnings}\njq is not in your PATH! - click for installation instructions | color=$STOPPED_VM_COLOR href=https://stedolan.github.io/jq/download/\n")
+    depsOK=0
+  fi
+  if [[ depsOK -eq 0 ]]; then
+    echo "🐋 ⛔ | color=$STOPPED_VM_COLOR"
+    echo '---'
+    echo "$warnings"
+    exit 0
+  fi
+}
+
 function printMenu() {
+  warnIfMissingDependencies
   # Bar title
   menuBarIcon="🐋 ⛔ | color=$STOPPED_VM_COLOR"
   for limavm in $(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | awk '{ print $1 }')
@@ -105,16 +127,5 @@ function processMenuCommand() {
   esac
 }
 
-function warnLimactlIsMissing() {
-  echo "🐋 ❌ | color=$STOPPED_VM_COLOR"
-  echo '---'
-  echo "limactl is not in your PATH! | color=$STOPPED_VM_COLOR"
-  echo "Lima home | href=https://github.com/lima-vm/lima"
-}
-
-if has limactl; then
-  printMenu
-  processMenuCommand "$@"
-else
-  warnLimactlIsMissing
-fi
+printMenu
+processMenuCommand "$@"

--- a/lima-plugin
+++ b/lima-plugin
@@ -86,19 +86,23 @@ function warnIfMissingDependencies() {
   fi
 }
 
-function printMenu() {
-  warnIfMissingDependencies
+function printMenuBarIcon() {
   # Bar title
+  local limaStatus
+  local menuBarIcon
   menuBarIcon="🐋 ⛔ | color=$STOPPED_VM_COLOR"
-  for limavm in $(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | awk '{ print $1 }')
-  do
-    vmstatus=$(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | grep "$limavm" | awk '{ print $2 }')
-    if [[ "$vmstatus" == 'Running' ]]; then
-      menuBarIcon="🐋 🏃 | color=$RUNNING_VM_COLOR"
-    fi
-  done
+  limaStatus="$(limactl list --json | jq -r '.status')"
+  if [[ "$limaStatus" == 'Running' ]]; then
+    menuBarIcon="🐋 🏃 | color=$RUNNING_VM_COLOR"
+  fi
   echo "$menuBarIcon"
   echo '---'
+}
+
+function printMenu() {
+  warnIfMissingDependencies
+
+  printMenuBarIcon
 
   for limavm in $(limactl list | grep -v 'NAME       STATUS     SSH                ARCH      DIR' | awk '{ print $1 }')
   do
@@ -110,8 +114,10 @@ function printMenu() {
     fi
     echo "$menuItem"
   done
+
   echo "force rescan | bash=limactl param1=list terminal=false refresh=true"
   echo "Lima home | href=https://github.com/lima-vm/lima"
+  limactl --version
 }
 
 function processMenuCommand() {

--- a/lima-plugin
+++ b/lima-plugin
@@ -88,7 +88,6 @@ function warnIfMissingDependencies() {
 
 function printMenuBarIcon() {
   # Bar title
-  local limaStatus
   local menuBarIcon
   menuBarIcon="🐋 ⛔ | color=$STOPPED_VM_COLOR"
 
@@ -112,14 +111,14 @@ function printMenu() {
 
   for raw in $(limactl list --json)
   do
-    name=$(echo $raw | jq -r '.name' )
-    vmstatus=$(echo $raw | jq -r '.status')
+    name=$(echo "$raw"| jq -r '.name' )
+    vmstatus=$(echo "$raw" | jq -r '.status')
     if [[ $vmstatus == 'Running' ]]; then
       menuItem="$name VM is running - ⛔ | color=$RUNNING_VM_COLOR | bash=$XBAR_PLUGIN param1=stop param2=$name terminal=false refresh=true"
     else
       menuItem="$name VM is stopped - ▶️ | color=$STOPPED_VM_COLOR | bash=$XBAR_PLUGIN param1=start param2=$name terminal=false refresh=true"
     fi
-    echo $menuItem
+    echo "$menuItem"
   done
 
   echo "force rescan | bash=limactl param1=list terminal=false refresh=true"


### PR DESCRIPTION
- We require `jq` and `limactl`, so if they're missing, add menu items that take us to the corresponding install instructions web pages instead of just failing mysteriously

- Deal with multiple VMs
  - Stop assuming there is only one `lima` VM
  - Stop assuming that if there is only one `lima` VM, it is named `default`

- Display `lima` version in menu

Closes https://github.com/unixorn/lima-xbar-plugin/issues/4