### PR TITLE
Add images submenu functionality and notification displays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-i: install
+i: lint install
 install:
 	cp lima-plugin ~/Library/Application\ Support/xbar/plugins/lima-plugin.10s
 

--- a/lima-plugin
+++ b/lima-plugin
@@ -71,12 +71,16 @@ logger -t 'limamenu' "XBAR_PLUGIN=$XBAR_PLUGIN"
 function warnIfMissingDependencies() {
   local depsOK=1
   local warnings=""
+  if ! has jq; then
+    warnings=$(printf "${warnings}\njq is not in your PATH! - click for installation instructions | color=$STOPPED_VM_COLOR href=https://stedolan.github.io/jq/download/\n")
+    depsOK=0
+  fi
   if ! has limactl; then
     warnings=$(printf "${warnings}limactl is not in your PATH! - click to get started | color=$STOPPED_VM_COLOR href=https://github.com/lima-vm/lima#getting-started\n")
     depsOK=0
   fi
-  if ! has jq; then
-    warnings=$(printf "${warnings}\njq is not in your PATH! - click for installation instructions | color=$STOPPED_VM_COLOR href=https://stedolan.github.io/jq/download/\n")
+  if ! has osascript; then
+    warnings=$(printf "${warnings}osascript is not in your PATH! - click to get started | color=$STOPPED_VM_COLOR\n")
     depsOK=0
   fi
   if [[ depsOK -eq 0 ]]; then

--- a/lima-plugin
+++ b/lima-plugin
@@ -194,11 +194,11 @@ function pullImage() {
   if [[ "$VM" != 'default' ]]; then
     export LIMA_INSTANCE="$VM"
   fi
-  displayNotification lima "Pulling ${imageName}..."
-  if lima nerdctl image pull "$imageName"; then
-    displayNotification Lima "Pulled $imageName"
+  displayNotification lima "Pulling ${imageName} on ${VM}..."
+  if lima nerdctl image pull "${imageName}"; then
+    displayNotification Lima "Pulled ${imageName}"
   else
-    displayAlert Lima "Failed to pull $imageName"
+    displayAlert Lima "Failed to pull ${imageName} on ${VM}"
   fi
 }
 
@@ -212,7 +212,12 @@ function rmImage() {
   if [[ "$VM" != 'default' ]]; then
     export LIMA_INSTANCE="$VM"
   fi
-  lima nerdctl image rm "$imageName"
+  displayNotification lima "Removing ${imageName} from ${VM}..."
+  if lima nerdctl image rm "${imageName}"; then
+    displayNotification Lima "Removed ${imageName}"
+  else
+    displayAlert Lima "Failed to remove ${imageName}"
+  fi
 }
 
 function processMenuCommand() {

--- a/lima-plugin
+++ b/lima-plugin
@@ -122,6 +122,7 @@ function printMenu() {
       for image in $(vmImages)
       do
         echo "----$image"
+        echo "------ pull | bash=$XBAR_PLUGIN param1=pull param2=$name param3=$image terminal=false refresh=true"
       done
     else
       echo "$name VM is stopped | color=$STOPPED_VM_COLOR"
@@ -150,10 +151,26 @@ function vmImages() {
   done
 }
 
+function pullImage() {
+  # arg1 = image
+  # arg2 = VM
+  local imageName
+  local VM
+  imageName="$1"
+  VM="$2"
+  if [[ "$VM" != 'default' ]]; then
+    export LIMA_INSTANCE="$VM"
+  fi
+  lima nerdctl image pull "$imageName"
+}
+
 function processMenuCommand() {
   case "$1" in
     images)
       vmImages "$2"
+    ;;
+    pull)
+      pullImage "$2" "$3" # pull imagename vmname
     ;;
     start)
       logger -t 'limamenu' "Starting $2"

--- a/lima-plugin
+++ b/lima-plugin
@@ -123,6 +123,7 @@ function printMenu() {
       do
         echo "----$image"
         echo "------ pull | bash=$XBAR_PLUGIN param1=pull param2=$name param3=$image terminal=false refresh=true"
+        echo "------ rm | bash=$XBAR_PLUGIN param1=rmImage param2=$name param3=$image terminal=false refresh=true"
       done
     else
       echo "$name VM is stopped | color=$STOPPED_VM_COLOR"
@@ -164,6 +165,19 @@ function pullImage() {
   lima nerdctl image pull "$imageName"
 }
 
+function rmImage() {
+  # arg1 = image
+  # arg2 = VM
+  local imageName
+  local VM
+  imageName="$1"
+  VM="$2"
+  if [[ "$VM" != 'default' ]]; then
+    export LIMA_INSTANCE="$VM"
+  fi
+  lima nerdctl image rm "$imageName"
+}
+
 function processMenuCommand() {
   case "$1" in
     images)
@@ -171,6 +185,9 @@ function processMenuCommand() {
     ;;
     pull)
       pullImage "$2" "$3" # pull imagename vmname
+    ;;
+    rmImage)
+      rmImage "$2" "$3" # pull imagename vmname
     ;;
     start)
       logger -t 'limamenu' "Starting $2"

--- a/lima-plugin
+++ b/lima-plugin
@@ -9,8 +9,9 @@
 # <xbar.author>Joe Block</xbar.author>
 # <xbar.author.github>unixorn</xbar.author.github>
 # <xbar.desc>Control Lima VM</xbar.desc>
-# <xbar.dependencies>Lima</xbar.dependencies>
+# <xbar.dependencies>jq,lima</xbar.dependencies>
 # <xbar.image>https://raw.githubusercontent.com/unixorn/lima-xbar-plugin/main/pix/limactl-screen-shot.png</xbar.image>
+# <xbar.abouturl>https://github.com/unixorn/lima-xbar-plugin/</xbar.abouturl>
 #
 # Dependencies: 
 #   lima - https://github.com/lima-vm/lima
@@ -101,6 +102,7 @@ function printMenuBarIcon() {
   echo '---'
 }
 
+# shellcheck disable=SC2059
 function printMenu() {
   warnIfMissingDependencies
 
@@ -114,11 +116,12 @@ function printMenu() {
     name=$(echo "$raw"| jq -r '.name' )
     vmstatus=$(echo "$raw" | jq -r '.status')
     if [[ $vmstatus == 'Running' ]]; then
-      menuItem="$name VM is running - ⛔ | color=$RUNNING_VM_COLOR | bash=$XBAR_PLUGIN param1=stop param2=$name terminal=false refresh=true"
+      echo "$name VM is running | color=$RUNNING_VM_COLOR"
+      echo "--⛔ Stop $name VM | bash=$XBAR_PLUGIN param1=stop param2=$name terminal=false refresh=true"
     else
-      menuItem="$name VM is stopped - ▶️ | color=$STOPPED_VM_COLOR | bash=$XBAR_PLUGIN param1=start param2=$name terminal=false refresh=true"
+      echo "$name VM is stopped | color=$STOPPED_VM_COLOR"
+      echo "--▶️ Start $name VM | bash=$XBAR_PLUGIN param1=start param2=$name terminal=false refresh=true"
     fi
-    echo "$menuItem"
   done
 
   echo "force rescan | bash=limactl param1=list terminal=false refresh=true"

--- a/lima-plugin
+++ b/lima-plugin
@@ -50,6 +50,34 @@ function has() {
   which "$@" > /dev/null 2>&1
 }
 
+function displayAlert() {
+  alertCommand="display alert \"$1\" message \"$2\""
+  osascript -e "$alertCommand"
+}
+
+function displayNotification() {
+  if [[ $# -eq 1 ]]; then
+    message_command="display notification \"$1\""
+    osascript -e "$message_command"
+  fi
+
+  if [[ $# -eq 2 ]]; then
+    message_command="display notification \"$2\" with title \"$1\""
+    osascript -e "$message_command"
+  fi
+
+  if [[ $# -eq 3 ]]; then
+    message_command="display notification \"$3\" with title \"$1\" subtitle \"$2\""
+    echo "message_command: $message_command"
+    osascript -e "$message_command"
+  fi
+
+  if [[ $# -eq 4 ]]; then
+    message_command="display notification \"$4\" with title  \"$1\" subtitle \"$2\" sound name \"$3\""
+    osascript -e "$message_command"
+  fi
+}
+
 # Set up a working scratch directory
 SCRATCH_D=$(mktemp -d)
 
@@ -63,16 +91,16 @@ trap cleanup EXIT
 export PATH="$PATH:/usr/local/bin"
 XBAR_PLUGIN="$0"
 
-logger -t 'limamenu' "RUNNING_VM_COLOR=$RUNNING_VM_COLOR"
-logger -t 'limamenu' "STOPPED_VM_COLOR=$STOPPED_VM_COLOR"
-logger -t 'limamenu' "XBAR_PLUGIN=$XBAR_PLUGIN"
-
 # shellcheck disable=SC2059
 function warnIfMissingDependencies() {
   local depsOK=1
   local warnings=""
   if ! has jq; then
     warnings=$(printf "${warnings}\njq is not in your PATH! - click for installation instructions | color=$STOPPED_VM_COLOR href=https://stedolan.github.io/jq/download/\n")
+    depsOK=0
+  fi
+  if ! has lima; then
+    warnings=$(printf "${warnings}lima is not in your PATH! - click to get started | color=$STOPPED_VM_COLOR href=https://github.com/lima-vm/lima#getting-started\n")
     depsOK=0
   fi
   if ! has limactl; then
@@ -166,7 +194,12 @@ function pullImage() {
   if [[ "$VM" != 'default' ]]; then
     export LIMA_INSTANCE="$VM"
   fi
-  lima nerdctl image pull "$imageName"
+  displayNotification lima "Pulling ${imageName}..."
+  if lima nerdctl image pull "$imageName"; then
+    displayNotification Lima "Pulled $imageName"
+  else
+    displayAlert Lima "Failed to pull $imageName"
+  fi
 }
 
 function rmImage() {
@@ -194,12 +227,20 @@ function processMenuCommand() {
       rmImage "$2" "$3" # pull imagename vmname
     ;;
     start)
-      logger -t 'limamenu' "Starting $2"
-      limactl start "$2"
+      displayNotification 'Lima' "Starting $2 VM"
+      if limactl start "$2"; then
+        displayNotification "Lima" "Started $2 VM successfully"
+      else
+        displayAlert "Lima" "Failed to start $2 VM"
+      fi
     ;;
     stop)
-      logger -t 'limamenu' "Stopping $2"
-      limactl stop "$2"
+      displayNotification 'Lima' "Stopping $2 VM"
+      if limactl stop "$2"; then
+        displayNotification "Lima" "Stopped $2 VM successfully"
+      else
+        displayAlert "Lima" "Failed to stop $2 VM"
+      fi
     ;;
   esac
 }

--- a/lima-plugin
+++ b/lima-plugin
@@ -118,6 +118,11 @@ function printMenu() {
     if [[ $vmstatus == 'Running' ]]; then
       echo "$name VM is running | color=$RUNNING_VM_COLOR"
       echo "--⛔ Stop $name VM | bash=$XBAR_PLUGIN param1=stop param2=$name terminal=false refresh=true"
+      echo "-- Images"
+      for image in $(vmImages)
+      do
+        echo "----$image"
+      done
     else
       echo "$name VM is stopped | color=$STOPPED_VM_COLOR"
       echo "--▶️ Start $name VM | bash=$XBAR_PLUGIN param1=start param2=$name terminal=false refresh=true"
@@ -129,8 +134,27 @@ function printMenu() {
   limactl --version
 }
 
+function vmImages() {
+  # default VM doesn't need to be specified
+  if [[ "$VM" != 'default' ]]; then
+    export LIMA_INSTANCE="$VM"
+  fi
+  # shellcheck disable=SC2001,SC2046,2005
+  imageList="[$(echo $(lima nerdctl images --format '{{json .}},') | sed 's/,$//')]"
+  # Can have spaces in our data, deal by using base64 (ugly)
+  for row in $(echo "${imageList}" | jq -r '.[] | @base64'); do
+    _jq() {
+      echo "${row}" | base64 --decode | jq -r "${1}"
+    }
+   echo "$(_jq '.Repository'):$(_jq '.Tag')"
+  done
+}
+
 function processMenuCommand() {
   case "$1" in
+    images)
+      vmImages "$2"
+    ;;
     start)
       logger -t 'limamenu' "Starting $2"
       limactl start "$2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

- Use Apple's Notification Manager (via `osascript`) to display notifications about some of our long-running tasks
  - Add `displayAlert()` for failure notifications so it doesn't disappear
  - Add `displayNotification()` that uses the macOS Notification Manager
  - Add notifications to image pull and remove operations
  - Add notifications to VM start/stop
- Add functionality to the image submenus
  - We now can pull or remove images from the `lima` menu
- Updated dependency checks
  - Add check for `lima` in `$PATH`
  - Add check for `osascript` in `$PATH`
- `Makefile` improvements
  - `make i` now runs `shellcheck` first
 
# Type of changes

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` and `#!/bin/bash` are allowed exceptions)
- [x] Scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
