### PR TITLE
Add /opt/homebrew/bin to $PATH when present and a directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,3 +9,15 @@
 - Rewrite in Python for speed and maintainability.
   - Now have submenus for container and image operations instead of just start/stop the VM
   - We send notifications to the Notification Manager
+
+## 1.2.0
+
+- Add option to pull new image into one of your Lima VMs.
+
+## 1.3.0
+
+- Add option to run an arbitrary `lima` command in a VM.
+
+## 1.3.1
+
+- Add `/opt/homebrew/bin` to the plugin's `$PATH` when it exists and is a directory.

--- a/lima-plugin
+++ b/lima-plugin
@@ -34,7 +34,7 @@ RUNNING_VM_COLOR = "#29cc00"
 # Stopped VM color (default red)
 STOPPED_VM_COLOR = "#ff0033"
 
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 
 def logSetup(level: str = "INFO"):
@@ -185,12 +185,7 @@ def listContainers(vm: str = "default"):
     :return dict:
     """
     containers = {}
-    if vm != "default":
-        env = dict(os.environ, LIMA_INSTANCE=vm)
-    else:
-        env = dict(os.environ)
-    newpath = "%s:/usr/local/bin" % env["PATH"]
-    env["PATH"] = newpath
+    env = prep_environment_for_lima(vm=vm)
 
     command = [
         "lima",
@@ -223,13 +218,7 @@ def listImages(vm: str = "default"):
     :return dict:
     """
     images = {}
-    if vm != "default":
-        env = dict(os.environ, LIMA_INSTANCE=vm)
-    else:
-        env = dict(os.environ)
-
-    newpath = "%s:/usr/local/bin" % env["PATH"]
-    env["PATH"] = newpath
+    env = prep_environment_for_lima(vm=vm)
 
     command = ["lima", "nerdctl", "images", "--format", "{{json .}}"]
     raw = jsonCommand(command=command, env=env)
@@ -262,9 +251,7 @@ def listVMs():
     """
     vmList = {}
 
-    env = dict(os.environ)
-    newpath = "%s:/usr/local/bin" % env["PATH"]
-    env["PATH"] = newpath
+    env = prep_environment_for_lima()
 
     vmRaw = subprocess.run(
         ["limactl", "list", "--json"], env=env, stdout=subprocess.PIPE
@@ -283,17 +270,24 @@ def prep_environment_for_lima(vm: str = "default", env: dict = dict(os.environ))
     """
     Set up an environment dictionary we can use to run a lima command.
 
-    Also adds /usr/local/bin to $PATH
+    Also adds /usr/local/bin, /opt/homebrew/bin and /opt/local/bin to $PATH
+    if they exist and are directories.
 
     :param str vm: VM to work in
     :param dict env: Environment variables to base returned environment on
 
-    :return dict: Environment dictionary, with /usr/local/bin added to $PATH
+    :return dict: Environment dictionary, with extra bindirs added to $PATH
     """
-    newpath = "%s:/usr/local/bin" % env["PATH"]
-    env["PATH"] = newpath
+    extrapaths = ["/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin"]
+    for p in extrapaths:
+        if os.path.isdir(p):
+            logging.info("Adding %s to $PATH", p)
+            newpath = "%s:%s" % (env["PATH"], p)
+            env["PATH"] = newpath
+    logging.info("New path: %s", env["PATH"])
 
     if vm != "default":
+        logging.info("Setting LIMA_INSTANCE to %s", vm)
         env["LIMA_INSTANCE"] = vm
     return env
 
@@ -443,8 +437,9 @@ def aboutMenu():
     """
     Print details about plugin
     """
+    env = prep_environment_for_lima()
     limaVersion = subprocess.run(
-        ["/usr/local/bin/limactl", "--version"], stdout=subprocess.PIPE
+        ["limactl", "--version"], stdout=subprocess.PIPE, env=env
     ).stdout.decode("utf-8")
 
     print("About…")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

`brew` doesn't always use `/usr/local/bin` any more, and macOS doesn't pass the `$PATH` from `.zshrc`/`.bashrc` to GUI applications which caused problems with a `brew`-installed version of `lima`.

`prep_environment_for_lima()` now adds a list of potential directories to `$PATH` if they exist and are directories - currently `/usr/local/bin`, `/opt/homebrew/bin` and `/opt/local/bin`.

Closes https://github.com/unixorn/lima-xbar-plugin/issues/24

# Type of changes

Bugfix

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [x] Any added/updated scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` and `#!/bin/bash` are allowed exceptions)
- [x] Added/updated scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No end-user should have to know if a script was written in `bash`, `python`, `ruby` or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
