### PR TITLE
Deal with Swiftbar change

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -47,7 +47,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,3 +21,7 @@
 ## 1.3.1
 
 - Add `/opt/homebrew/bin` to the plugin's `$PATH` when it exists and is a directory.
+
+## 1.3.2
+
+- Swiftbar started capturing `stderr` in addition to `stdout`, causing log messages to spam the menu bar. Default to log level critical so we don't spam log messages (that no one was seeing anyway) except when we're testing.

--- a/lima-plugin
+++ b/lima-plugin
@@ -5,7 +5,7 @@
 # Copyright 2021, Joe Block <jpb@unixorn.net>
 #
 # <xbar.title>Lima Control</xbar.title>
-# <xbar.version>v1.0</xbar.version>
+# <xbar.version>v1.3.2</xbar.version>
 # <xbar.author>Joe Block</xbar.author>
 # <xbar.author.github>unixorn</xbar.author.github>
 # <xbar.desc>Control Lima VM</xbar.desc>

--- a/lima-plugin
+++ b/lima-plugin
@@ -34,7 +34,7 @@ RUNNING_VM_COLOR = "#29cc00"
 # Stopped VM color (default red)
 STOPPED_VM_COLOR = "#ff0033"
 
-VERSION = "1.3.1"
+VERSION = "1.3.2"
 
 
 def logSetup(level: str = "INFO"):
@@ -72,7 +72,7 @@ def parseCLI():
         type=str.upper,
         help="set log level",
         choices=["DEBUG", "INFO", "ERROR", "WARNING", "CRITICAL"],
-        default="INFO",
+        default="CRITICAL",
     )
     parser.add_argument(
         "--vm", "--virtual-machine", type=str, help="Which vm to use", default="default"
@@ -325,7 +325,7 @@ def imageOps(action: str, image: str, vm: str = "default"):
     :param str image: What image to do the action on
     :param str vm: Which VM is the image in?
     """
-    logging.critical("imageOps")
+    logging.info("imageOps")
     logging.info("action: %s" % action)
     logging.info("image: %s" % image)
     logging.info("vm: %s" % vm)
@@ -371,7 +371,7 @@ def vmOps(action: str, vm: str = "default"):
     :param str action: What action to run - should be start or stop
     :param str vm: Name of VM to act on
     """
-    logging.critical("vmOps")
+    logging.info("vmOps")
     logging.debug("action: %s" % action)
     logging.debug("vm: %s" % vm)
 


### PR DESCRIPTION
# Description

Swiftbar now is capturing `STDERR` in addition to `STDOUT`, which made all the logging info get spammed to the menubar.

We now default to log level `CRITICAL` - log output is only necessary during debugging, so this stifles all log output during normal runs by Swiftbar and Xbar.

Closes #26

# Type of changes

Bugfix to cope with Swiftbar changes.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any added/updated scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` and `#!/bin/bash` are allowed exceptions)
- [ ] Added/updated scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No end-user should have to know if a script was written in `bash`, `python`, `ruby` or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
