### PR TITLE
Add more candidate directories to be added to $PATH

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -53,6 +53,8 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_LINTERS: SPELL_CSPELL
+          # SPELL_MISSPELL_FILTER_REGEX_EXCLUDE: '(\.yml)'
 
       # Upload Mega-Linter artifacts. They will be available on Github action page "Artifacts" section
       - name: Archive production artifacts

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -48,7 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: nvuillam/mega-linter@v4
+        uses: nvuillam/mega-linter@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/Changelog.md
+++ b/Changelog.md
@@ -25,3 +25,13 @@
 ## 1.3.2
 
 - Swiftbar started capturing `stderr` in addition to `stdout`, causing log messages to spam the menu bar. Default to log level critical so we don't spam log messages (that no one was seeing anyway) except when we're testing.
+
+## 1.3.3
+
+dd more candidate directories to be added to $PATH
+
+- Check for `~/homebrew/bin` and `~/homebrew/sbin` to cope when homebrew
+  is installed in a user's home directory. Closes https://github.com/unixorn/lima-xbar-plugin/issues/28
+- While we're in there, check for `/usr/local/sbin`,
+  `/opt/homebrew/sbin`, `/opt/local/sbin`, `~/bin` and `~/sbin`
+  directories too.

--- a/lima-plugin
+++ b/lima-plugin
@@ -270,15 +270,26 @@ def prep_environment_for_lima(vm: str = "default", env: dict = dict(os.environ))
     """
     Set up an environment dictionary we can use to run a lima command.
 
-    Also adds /usr/local/bin, /opt/homebrew/bin and /opt/local/bin to $PATH
-    if they exist and are directories.
+    Also adds /usr/local/{s}bin, /opt/homebrew/{s}bin, /opt/local/{s}bin,
+    ~/homebrew/{s}bin and ~/{s}bin to $PATH if they exist and are directories.
 
     :param str vm: VM to work in
     :param dict env: Environment variables to base returned environment on
 
     :return dict: Environment dictionary, with extra bindirs added to $PATH
     """
-    extrapaths = ["/usr/local/bin", "/opt/homebrew/bin", "/opt/local/bin"]
+    extrapaths = [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/opt/local/bin",
+        "/opt/local/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        f"{os.environ.get('HOME')}/bin",
+        f"{os.environ.get('HOME')}/homebrew/bin",
+        f"{os.environ.get('HOME')}/homebrew/sbin",
+        f"{os.environ.get('HOME')}/sbin",
+    ]
     for p in extrapaths:
         if os.path.isdir(p):
             logging.info("Adding %s to $PATH", p)

--- a/lima-plugin
+++ b/lima-plugin
@@ -34,7 +34,7 @@ RUNNING_VM_COLOR = "#29cc00"
 # Stopped VM color (default red)
 STOPPED_VM_COLOR = "#ff0033"
 
-VERSION = "1.3.2"
+VERSION = "1.3.3"
 
 
 def logSetup(level: str = "INFO"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lima-plugin"
-version = "0.1.0"
+version = "1.3.3"
 description = "Xbar and Swiftbar plugin to control lima"
 authors = ["Joe Block <jpb@unixorn.net>"]
 license = "Apache 2.0"


### PR DESCRIPTION
# Description

- Bump version to 1.3.3
- Check for `~/homebrew/bin` and `~/homebrew/sbin` to cope when homebrew is installed in a user's home directory. Closes https://github.com/unixorn/lima-xbar-plugin/issues/28
- While we're in there, check for `/usr/local/sbin`, `/opt/homebrew/sbin`, `/opt/local/sbin`, `~/bin` and `~/sbin` directories too.

# Type of changes

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] All new and existing tests pass.
- [ ] Any added/updated scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` and `#!/bin/bash` are allowed exceptions)
- [ ] Added/updated scripts are marked executable
- [ ] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No end-user should have to know if a script was written in `bash`, `python`, `ruby` or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
