### PR TITLE
refactor (Makefile): error handling and help target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ETC
+requirements.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,53 @@
-i: format install
-install: format
-	cp lima-plugin ~/Library/Application\ Support/xbar/plugins/lima-plugin.10s
+#!/usr/bin/make -f
 
+.DEFAULT_GOAL := help
+
+GREEN := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE := $(shell tput -Txterm setaf 7)
+CYAN := $(shell tput -Txterm setaf 6)
+RESET := $(shell tput -Txterm sgr0)
+
+.PHONY: all
+all: i install l lint r requirements f format t test ## run all targets
+
+i: format install
+install: format ## install the plugin
+    @if logname >/dev/null 2>&1; then \
+        logged_in_user=$$(logname); \
+    else \
+        logged_in_user=$$(whoami); \
+    fi; \
+    @if [ -d "$${logged_in_user}/Library/Application Support/xbar/plugins" ]; then \
+        mkdir -p "$${logged_in_user}/Library/Application Support/xbar/plugins"; \
+    fi; \
+    cp lima-plugin "$${logged_in_user}/Library/Application Support/xbar/plugins/lima-plugin.10s"
+
+# TODO: replace shellcheck with ruff or another linter (shellcheck doesn't work with python scripts)
+# * cf. commit: e6b3896
 l: lint
-lint:
+lint: ## lint the plugin
 	shellcheck lima-plugin
 
 r: requirements
-requirements:
+requirements: ## export the requirements.txt file
 	poetry export -f requirements.txt --output requirements.txt
 
 f: format
-format:
+format: ## format the plugin
 	poetry run black lima-plugin
 
 t: test
-test: format
+test: format ## test the plugin
 	poetry run ./lima-plugin
 
+help: ## show this help
+	@echo ''
+	@echo 'Usage:'
+	@echo '    ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} { \
+		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "    ${YELLOW}%-20s${GREEN}%s${RESET}\n", $$1, $$2} \
+		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
+		}' $(MAKEFILE_LIST)


### PR DESCRIPTION
When running the Makefile as-is it fails on the install target if the directory doesn't exist and runs all targets. This PR adds error handling and a new help target/goal that prints available options (ignores short options however).

# Description

- `chmod +x`
- shebang
- default goal is now the help target
- mark targets as phony ([avoid filename collisions](https://how.wtf/what-does-phony-mean-in-a-makefile.html))
- error handling for install target
- raise issue in todo for deprecated shellcheck call
- help comments
- help target (`make` / `make help`)
- exclude requirements.txt (generated by Makefile)

![Screenshot 2024-05-15 at 9 07 03 PM](https://github.com/unixorn/lima-xbar-plugin/assets/4097471/f105459b-bf3f-40db-bb02-6dd27d0daa04)

# Type of changes

# Checklist

- [x] All new and existing tests pass.
- [x] Any added/updated scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` and `#!/bin/bash` are allowed exceptions)
- [x] Added/updated scripts are marked executable
- [x] Scripts _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No end-user should have to know if a script was written in `bash`, `python`, `ruby` or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [x] I have confirmed that the link(s) in my PR are valid.

# License Acceptance

- [x] This repository is Apache version 2.0 licensed (some scripts may have alternate licensing inline in their code) and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.
